### PR TITLE
Add missing library dependency to spec file

### DIFF
--- a/smartmet-plugin-wcs.spec
+++ b/smartmet-plugin-wcs.spec
@@ -23,6 +23,7 @@ BuildRequires: smartmet-engine-gis-devel >= 17.8.28
 BuildRequires: smartmet-engine-querydata-devel >= 17.8.28
 BuildRequires: smartmet-library-gis-devel >= 17.8.28
 BuildRequires: smartmet-library-macgyver-devel >= 17.8.28
+BuildRequires: smartmet-library-newbase-devel >= 17.9.11
 BuildRequires: smartmet-library-spine-devel >= 17.8.28
 BuildRequires: xerces-c-devel
 BuildRequires: xqilla-devel
@@ -44,6 +45,7 @@ Requires: smartmet-engine-gis >= 17.8.28
 Requires: smartmet-engine-gis >= 17.8.28
 Requires: smartmet-engine-querydata >= 17.8.28
 Requires: smartmet-library-macgyver >= 17.8.28
+Requires: smartmet-library-newbase >= 17.9.11
 Requires: smartmet-library-spine >= 17.8.28
 Requires: smartmet-server >= 17.8.28
 Requires: xerces-c


### PR DESCRIPTION
Newbase library is used in the plugin, so it naturally depends on it.