### PR TITLE
Change configurations in base tests to use current implementation of …

### DIFF
--- a/test/base/cnf/smartmet_test.conf
+++ b/test/base/cnf/smartmet_test.conf
@@ -28,14 +28,14 @@ engines:
 {
 	querydata:
 	{
-		configfile      = "cnf/querydata_test.conf";
-		libfile         = "../../../../engines/querydata/querydata.so";
+		configfile      = "querydata_test.conf";
+		libfile         = "../../../../../engines/querydata/querydata.so";
 	};
 
 	gis:
 	{
-		configfile      = "../../../../engines/gis/test/cnf/gis.conf";
-		libfile         = "../../../../engines/gis/gis.so";
+		configfile      = "../../../../../engines/gis/test/cnf/gis.conf";
+		libfile         = "../../../../../engines/gis/gis.so";
 	};
 };
 
@@ -43,8 +43,8 @@ plugins:
 {
 	wcs:
 	{
-		configfile      = "cnf/wcs_plugin_test.conf";
-                libfile         = "../../wcs.so";
+		configfile      = "wcs_plugin_test.conf";
+		libfile         = "../../../wcs.so";
 	};
 };
 


### PR DESCRIPTION
…Spine::ConfigBase

ConfigBase class is using relative paths from the configuration file now.