### PR TITLE
Configurable Capability in multiple languages - Issue #3

### DIFF
--- a/cnf/templates/capabilities.template
+++ b/cnf/templates/capabilities.template
@@ -35,177 +35,6 @@
       tulee rekisteröityä palveluun sekä hyväksyä käyttöehdot saadakseen pääsyn palveluun.
     </ows:Fees>
     <ows:AccessConstraints>
-<TMPL_else>
-  <ows:ServiceIdentification>
-    <ows:Title>Finnish Meteorological Institute's Open Data Download Service</ows:Title>
-    <ows:Abstract>
-      Finnish Meteorological Institute's Open Data Download Service provides data
-      free-of-charge for public use. The producer of open data is the Finnish
-      Meteorological Institute.
-    </ows:Abstract>
-    <ows:Keywords>
-      <ows:Keyword>Forecast</ows:Keyword>
-      <ows:Keyword>Model</ows:Keyword>
-      <ows:Keyword>Hirlam</ows:Keyword>
-      <ows:Type>String</ows:Type>
-    </ows:Keywords>
-    <ows:ServiceType>WCS</ows:ServiceType>
-    <ows:ServiceTypeVersion><TMPL_var version></ows:ServiceTypeVersion>
-    <ows:Fees>
-      The use of this service and the returned data is free-of-charge, but users must
-      register and agree to the terms of service to gain access to the data.
-    </ows:Fees>
-    <ows:AccessConstraints>
-</TMPL_if>
-<TMPL_if in_set(language, "fin")>
-1.7.2014
-
-1. Yleistä
-Aineiston käyttöoikeutta rajoittavat tämän lisenssin mukaiset käyttöehdot:
-
-Avoin data -aineiston tuottaja ja tekijänoikeuden tai tietokantasuojan haltijat ovat kukin oman aineistonsa osalta seuraavat: Ilmatieteen laitos, Liikennevirasto ja muut tiedontuottajat (jäljempänä lisenssin myöntäjä). Muut tiedontuottajat on lueteltu liitteessä 1.
-
-Aineistoa käyttäessä on aineiston tai sitä sisältävän tai hyödyntävän palvelun yhteyteen liitettävä maininta alkuperäislähteestä ja aineistoversion ajankohdasta seuraavasti:
-- aineiston tuottaja ja hakuajankohdan päiväys
-- ilmoitus mikäli aineistoa on muokattu
-
-
-Lisenssin saajalla tarkoitetaan luonnollista tai juridista henkilöä, joka ottaa tämän lisenssin alaisen aineiston käyttöön.
-
-Lisenssin myöntäjä ei peri lisenssin alaisen aineiston käytöstä maksua.
-
-Vastaanottamalla aineistoa lisenssin saaja hyväksyy tämän lisenssin ehdot.
-
-2. Lisenssin ehdot
-2.1. Käyttöoikeudet
-Tämä on maailmanlaajuisen, maksuttoman, peruuttamattoman rinnakkaisen käyttöoikeuden myöntävä lisenssi, jonka mukaan lisenssin saajan vastaanottamaa aineistoa voi vapaasti:
-- kopioida, levittää ja julkaista,
-- muokata ja hyödyntää kaupallisesti ja ei-kaupallisesti,
-- yhdistellä muihin tuotteisiin ja
-- käyttää osana sovellusta tai palvelua.
-
-2.2. Lisenssin saajan velvollisuudet ja vastuut
-Lisenssin saajan on aineistoa tai siitä tehtyjä tuotteita käyttäessään ja edelleen luovuttaessaan:
-- mainittava aineiston alkuperäislähde kohdan 1. Yleistä mukaisesti.
-- esitettävä tämän lisenssin kopio tai linkki siihen.
-- vaadittava tämän lisenssin kohdan 1. Yleistä mukaista nimeämiskäytännön noudattamista myöntäessään lisenssejä tuotteeseen tai palveluun, jossa käyttää tämän lisenssin alaista aineistoa tai sen osaa.
-poistettava maininta alkuperäislähteestä, mikäli lisenssin myöntäjä sitä erikseen vaatii.
-- lentosäähavaintosanomiin (METAR) sovelletaan oheisen liitteen 2 mukaisia lisäehtoja.
-
-Lisenssin saajan ja lisenssin myöntäjän välille ei tämän lisenssin myötä synny yhteistyö- tai liikesuhdetta. Lisenssin saaja ei saa aineiston yhteydessä ilmaista, että lisenssin myöntäjä tukisi tai suosittelisi kyseistä aineiston käyttötapaa.
-
-Lisenssin myöntäjän ylläpitämän aineiston latauspalvelun häiriökäyttö on kielletty.
-
-2.3. Lisenssin myöntäjän velvollisuudet ja vastuut
-Lisenssin myöntäjä vastaa, että sillä on oikeus luovuttaa lisenssi kohdassa 1. Yleistä nimettyyn aineistoon.
-
-Aineisto on lisensoitu sellaisenaan eikä lisenssin myöntäjä vastaa aineiston perusteella tehdyistä päätöksistä, aineistossa mahdollisesti esiintyvistä virheistä eikä aineiston käytöstä aiheutuvista välittömistä tai välillisistä vahingoista. Lisenssin myöntäjä ei myönnä aineistolle tai siinä olevien tietojen oikeellisuudelle tai ajantasaisuudelle takuuta.
-
-Lisenssin myöntäjä ei takaa, että aineisto olisi jatkuvasti saatavilla, ja lisenssin myöntäjä voi lopettaa aineiston jakelun ennalta ilmoittamatta. Lisenssin myöntäjä voi myös muuttaa aineiston latausrajapintaa ennalta ilmoittamatta.
-
-3. Sovellettava laki
-Tähän lisenssiin sovelletaan Suomen lakia.
-
-4. Muutokset tähän lisenssiin
-Lisenssin myöntäjä voi milloin tahansa muuttaa lisenssin ehtoja tai soveltaa aineistoon eri lisenssiä. Tämän lisenssin ehtoja sovelletaan kuitenkin edelleen niihin yksittäisiin aineistoihin, jotka oli lisenssin muuttuessa jo ladattu.
-
-
-LIITE 1
-
-Muut tiedontuottajat
-(Toistaiseksi ei muita tiedontuottajia.)
-
-LIITE 2
-
-Lentosäähavaintosanomat (METAR) -aineistoon liittyvät lisäehdot
-
-YLEISTÄ
-Lentokentillä tuotetaan kahta eri säähavaintoaineistoa: lentosäähavaintosanomia (METAReita) ja hetkellisiä säähavaintoja. Lentosäähavaintosanomat (METARit) koostetaan yleensä lentokentän eri havaintolaitteiden datasta noudattaen ICAO Annex 3:n* määräyksiä. Hetkelliset säähavainnot ovat puolestaan lentokentän tiettyjen havaintolaitteiden havaintoja. Lentosäähavaintosanoman (METARin) ja lentopaikan hetkellisen säähavainnon välillä voi olla suuriakin eroja johtuen erilaisista laskentamenetelmistä ja päättelyketjuista.
-
-Ilmatieteen laitos on nimetty yksinoikeudella lentosäähavaintopalveluiden tarjoajaksi Suomen lentotiedotusalueelle 31.1.2020 asti. (LVM päätös 5.3.2013 dnro LVM/1185/02/2012)
-
-ICAO Annex 3:n* mukaan METAR tulee esittää määritetyn muotoisena ja sisältöisenä säähavaintosanomana.
-
-DISCLAIMER -SUOSITUS
-Sovelluksissa, joissa käytetään lentosäähavaintosanomia (METAReita), tulisi esittää disclaimer "Palvelussa esitetyt METAR-sanomat voivat puuttua tai olla käytettävissä myöhemmin kuin ilmailun viestiverkossa."
-
-*Annex 3 to the Convention on International Civil Aviation – Meteorological Service for International Service for International Air Navigation
-<TMPL_else>
-1.7.2014
-
-1. General
-The use of the material is governed by the terms and conditions specified in this licence.
-
-The following are regarded as the producer of open data and the holders of copyright or database rights: the Finnish Meteorological Institute, the Finnish Transport Agency and other data producers as specified in Annex 1 (hereinafter the licensors).
-
-When used, the material or the service including or utilising the material must be accompanied by information on the original source and the date of the current version as follows:
-- the producer of the material and the retrieval date;
-- a note if the data have been adapted.
-
-The licensee refers to a natural or legal person who takes the material covered by this licence into use.
-
-The licensor does not charge a fee for using the material subject to this licence.
-
-By receiving the material, the licensee accepts the terms of this licence.
-
-2. Terms of use
-
-2.1. The right to use the material
-This licence grants a worldwide, free of charge, perpetual, non-exclusive right, under which the material received by the licensee can be freely:
-- copied, distributed and published;
-- adapted and utilised commercially and non-commercially;
-- combined with other products; and
-- used as part of an application or a service.
-
-2.2. The licensee's obligations and responsibilities
-When using and transmitting the material or products made of the material, the licensee must:
-
-- mention the original source of the material in accordance with Section 1. General;
-- present a copy of this licence or a link to it;
-- require that the attribution practice specified under Section 1. General of this licence is followed when the licensee grants licenses to a product or service that uses some or all of the material subject to this licence;
-remove the note of the original source if so required explicitly by the licensor.
-- Special additional terms as stated in Annex 2 apply to aviation weather reports (METAR).
-
-This licence does not create any cooperation or business relationship between the licensee and the licensor. In connection with the material, the licensee must not indicate that the licensor endorses or recommends the licensee's use of the material.
-
-Malicious use of the download service maintained by the licensor is prohibited.
-
-2.3. The licensor's obligations and responsibilities
-The licensor is responsible for ensuring that it has the right to grant a licence to the material specified in Section 1. General.
-
-The material is licensed ‘as is' and the licensor is not liable for decisions made on the basis of the material, for any errors in the material, or for direct or indirect damage caused by the use of the material. The licensor does not grant any warranty for the material and does not guarantee that the material is accurate and up-to-date.
-
-The licensor does not guarantee that the material is constantly available, and the licensor may terminate the distribution of the material without prior notice. The licensor may also change the interface for downloading the material without prior notice.
-
-3. Applicable law
-This licence is governed by Finnish law.
-
-4. Changes to this licence
-At any time, the licensor may change the licence terms or may apply a different licence to the material. However, the terms of this licence continue to be applied to individual materials that had already been downloaded when the licence changed.
-
-ANNEX 1
-
-Other data producers
-(No other data producers.)
-
-ANNEX 2
-
-Additional terms for aviation weather reports (METAR)
-
-GENERAL ASPECTS
-
-The airports produce two different kinds of weather reports: aviation weather reports (METAR) and weather observations. Aviation weather reports (METAR) are generally compiled from the data collected by the airport's various observation equipment in compliance with the regulations in ICAO Annex 3*. Weather observations refer to data collected by certain observation equipment at an airport. Due to different calculation methods and deduction chains, the differences between an aviation weather report (METAR) and a weather observation at an aerodrome can be quite large.
-
-The Finnish Meteorological Institute has been appointed as the designated producer of aviation weather reports in the Finnish Flight Information Region until 31 January 2010 (Decision of the Finnish Ministry of Transport and Communications, 5 March 2013, record number LVM/1185/02/2012).
-
-ICAO Annex 3* establishes specific formal and material requirements for METAR weather reports.
-
-RECOMMENDED DISCLAIMER
-Applications containing aviation weather reports (METAR) should contain the following disclaimer: "METAR reports may be missing or available later than in the Aeronautical Fixed Telecommunication Network (AFTN)"
-
-*Annex 3 to the Convention on International Civil Aviation – Meteorological Service for International Service for International Air Navigation
-</TMPL_if>
-<TMPL_if in_set(language, "fin")>
     </ows:AccessConstraints>
   </ows:ServiceIdentification>
   <ows:ServiceProvider>
@@ -225,39 +54,59 @@ Applications containing aviation weather reports (METAR) should contain the foll
           <ows:Country>Suomi</ows:Country>
           <ows:ElectronicMailAddress>avoin-data@fmi.fi</ows:ElectronicMailAddress>
         </ows:Address>
-<TMPL_else>
-    </ows:AccessConstraints>
-  </ows:ServiceIdentification>
-  <ows:ServiceProvider>
-    <ows:ProviderName>Finnish Meteorological Institute</ows:ProviderName>
-    <ows:ProviderSite xlink:href="http://en.ilmatieteenlaitos.fi"/>
-    <ows:ServiceContact>
-      <ows:ContactInfo>
-        <ows:Phone>
-          <ows:Voice>+358 29 539 1000</ows:Voice>
-          <ows:Facsimile>+358 29 539 2303</ows:Facsimile>
-        </ows:Phone>
-        <ows:Address>
-          <ows:DeliveryPoint>P.O. BOX 503</ows:DeliveryPoint>
-          <ows:City>Helsinki</ows:City>
-          <ows:AdministrativeArea>Uusimaa</ows:AdministrativeArea>
-          <ows:PostalCode>00101</ows:PostalCode>
-          <ows:Country>Finland</ows:Country>
-          <ows:ElectronicMailAddress>avoin-data@fmi.fi</ows:ElectronicMailAddress>
-        </ows:Address>
-</TMPL_if>
-        <TMPL_if in_set(language, "fin")><ows:OnlineResource xlink:href="http://ilmatieteenlaitos.fi/avoin-data"/><TMPL_else><ows:OnlineResource xlink:href="http://en.ilmatieteenlaitos.fi/open-data"/></TMPL_if>
+
+        <ows:OnlineResource xlink:href="http://ilmatieteenlaitos.fi/avoin-data"/>
         <ows:ContactInstructions>
-<TMPL_if in_set(language, "fin")>
           Saadaksesi teknistä apua tai antaaksesi palvelua koskevia virheilmoituksia, ole hyvä ja ota yhteyttä www-sivun http://ilmatieteenlaitos.fi/avoin-data kautta.
-<TMPL_else>
-          For technical help or error reports considering FMI Open Data Web Services, please consult our web page http://en.ilmatieteenlaitos.fi/open-data
-</TMPL_if>
         </ows:ContactInstructions>
       </ows:ContactInfo>
       <ows:Role>PointOfContact</ows:Role>
     </ows:ServiceContact>
-  </ows:ServiceProvider><TMPL_if DEFINED(operation.GetCapabilities && operation.DescribeCoverage)>
+<TMPL_else>
+  <TMPL_if DEFINED(Capabilities && Capabilities.ServiceIdentification)><ows:ServiceIdentification><TMPL_if DEFINED(Capabilities.ServiceIdentification.Title)>
+    <ows:Title><TMPL_var Capabilities.ServiceIdentification.Title></ows:Title></TMPL_if><TMPL_if DEFINED(Capabilities.ServiceIdentification.Abstract)>
+    <ows:Abstract><TMPL_var Capabilities.ServiceIdentification.Abstract>
+    </ows:Abstract></TMPL_if><TMPL_if DEFINED(Capabilities.ServiceIdentification.Keywords && Capabilities.ServiceIdentification.Keywords.Keyword)>
+    <ows:Keywords><TMPL_foreach Capabilities.ServiceIdentification.Keywords.Keyword as keyword>
+      <ows:Keyword><TMPL_var keyword></ows:Keyword></TMPL_foreach><TMPL_if DEFINED(Capabilities.ServiceIdentification.Keywords.Type)>
+      <ows:Type><TMPL_var Capabilities.ServiceIdentification.Keywords.Type></ows:Type></TMPL_if>
+    </ows:Keywords></TMPL_if>
+    <ows:ServiceType>WCS</ows:ServiceType>
+    <ows:ServiceTypeVersion><TMPL_var version></ows:ServiceTypeVersion>
+    <ows:Fees><TMPL_if DEFINED(Capabilities.ServiceIdentification.Fees)>
+      <TMPL_var Capabilities.ServiceIdentification.Fees></TMPL_if>
+    </ows:Fees><TMPL_if DEFINED(Capabilities.ServiceIdentification.AccessConstraints.eng)>
+    <ows:AccessConstraints><TMPL_var Capabilities.ServiceIdentification.AccessConstraints.eng>
+    </ows:AccessConstraints></TMPL_if>
+  </ows:ServiceIdentification></TMPL_if>
+  <TMPL_if DEFINED(Capabilities && Capabilities.ServiceProvider && Capabilities.ServiceProvider.ProviderName && Capabilities.ServiceProvider.ServiceContact)><ows:ServiceProvider>
+    <ows:ProviderName><TMPL_var Capabilities.ServiceProvider.ProviderName></ows:ProviderName>
+    <TMPL_if DEFINED(Capabilities.ServiceProvider.ProviderSite && Capabilities.ServiceProvider.ProviderSite.href)><ows:ProviderSite xlink:href="<TMPL_var Capabilities.ServiceProvider.ProviderSite.href>"/></TMPL_if>
+    <ows:ServiceContact>
+      <TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.ContactInfo)><ows:ContactInfo><TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.ContactInfo.Phone)>
+        <ows:Phone><TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.ContactInfo.Phone.Voice)>
+          <ows:Voice><TMPL_var Capabilities.ServiceProvider.ServiceContact.ContactInfo.Phone.Voice></ows:Voice></TMPL_if><TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.ContactInfo.Phone.Facsimile)>
+          <ows:Facsimile><TMPL_var Capabilities.ServiceProvider.ServiceContact.ContactInfo.Phone.Facsimile></ows:Facsimile></TMPL_if>
+        </ows:Phone></TMPL_if><TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address)>
+        <ows:Address><TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.DeliveryPoint)>
+          <ows:DeliveryPoint><TMPL_var Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.DeliveryPoint></ows:DeliveryPoint></TMPL_if><TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.City)>
+          <ows:City><TMPL_var Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.City></ows:City></TMPL_if><TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.AdministrativeArea)>
+          <ows:AdministrativeArea><TMPL_var Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.AdministrativeArea></ows:AdministrativeArea></TMPL_if><TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.PostalCode)>
+          <ows:PostalCode><TMPL_var Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.PostalCode></ows:PostalCode></TMPL_if><TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.Country)>
+          <ows:Country><TMPL_var Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.Country></ows:Country></TMPL_if><TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.ElectronicMailAddress)>
+          <ows:ElectronicMailAddress><TMPL_var Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.ElectronicMailAddress></ows:ElectronicMailAddress></TMPL_if>
+        </ows:Address></TMPL_if><TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.ContactInfo.OnlineResource)>
+
+        <ows:OnlineResource xlink:href="http://en.ilmatieteenlaitos.fi/open-data"/></TMPL_if><TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.ContactInfo.ContactInstructions)>
+        <ows:ContactInstructions>
+
+          <TMPL_var Capabilities.ServiceProvider.ServiceContact.ContactInfo.ContactInstructions>
+
+        </ows:ContactInstructions></TMPL_if>
+      </ows:ContactInfo></TMPL_if>
+      <TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.Role)><ows:Role><TMPL_var Capabilities.ServiceProvider.ServiceContact.Role></ows:Role></TMPL_if>
+    </ows:ServiceContact>
+  </ows:ServiceProvider></TMPL_if></TMPL_if><TMPL_if DEFINED(operation.GetCapabilities && operation.DescribeCoverage)>
   <ows:OperationsMetadata>
     <ows:Operation name="GetCapabilities">
       <ows:DCP>

--- a/cnf/templates/capabilities.template
+++ b/cnf/templates/capabilities.template
@@ -14,69 +14,22 @@
   http://www.opengis.net/ows/2.0 http://schemas.opengis.net/ows/2.0/owsAll.xsd
   http://inspire.ec.europa.eu/schemas/inspire_dls/1.0 http://inspire.ec.europa.eu/schemas/inspire_dls/1.0/inspire_dls.xsd
   http://inspire.ec.europa.eu/schemas/common/1.0 http://inspire.ec.europa.eu/schemas/common/1.0/common.xsd">
-<TMPL_if in_set(language, "fin")>
-  <ows:ServiceIdentification>
-    <ows:Title>Ilmatieteen laitoksen avoimen datan latauspalvelu</ows:Title>
-    <ows:Abstract>
-      Ilmatieteen laitoksen avoimen datan latauspalvelussa on saatavilla tietoaineistoja
-      maksutta julkisen käyttöön. Tietoaineistoja latauspalveluun tuottavat Ilmatieteen
-      laitos.
-    </ows:Abstract>
-    <ows:Keywords>
-      <ows:Keyword>Ennuste</ows:Keyword>
-      <ows:Keyword>Ennustemalli</ows:Keyword>
-      <ows:Keyword>Hirlam</ows:Keyword>
-      <ows:Type>String</ows:Type>
-    </ows:Keywords>
-    <ows:ServiceType>WCS</ows:ServiceType>
-    <ows:ServiceTypeVersion><TMPL_var version></ows:ServiceTypeVersion>
-    <ows:Fees>
-      Tämän palvelun käyttö sekä palvelusta ladattu data on maksutonta, mutta käyttäjien
-      tulee rekisteröityä palveluun sekä hyväksyä käyttöehdot saadakseen pääsyn palveluun.
-    </ows:Fees>
-    <ows:AccessConstraints>
-    </ows:AccessConstraints>
-  </ows:ServiceIdentification>
-  <ows:ServiceProvider>
-    <ows:ProviderName>Ilmatieteen laitos</ows:ProviderName>
-    <ows:ProviderSite xlink:href="http://ilmatieteenlaitos.fi"/>
-    <ows:ServiceContact>
-      <ows:ContactInfo>
-        <ows:Phone>
-          <ows:Voice>+358 29 539 1000</ows:Voice>
-          <ows:Facsimile>+358 29 539 2303</ows:Facsimile>
-        </ows:Phone>
-        <ows:Address>
-          <ows:DeliveryPoint>PL 503</ows:DeliveryPoint>
-          <ows:City>Helsinki</ows:City>
-          <ows:AdministrativeArea>Uusimaa</ows:AdministrativeArea>
-          <ows:PostalCode>00101</ows:PostalCode>
-          <ows:Country>Suomi</ows:Country>
-          <ows:ElectronicMailAddress>avoin-data@fmi.fi</ows:ElectronicMailAddress>
-        </ows:Address>
 
-        <ows:OnlineResource xlink:href="http://ilmatieteenlaitos.fi/avoin-data"/>
-        <ows:ContactInstructions>
-          Saadaksesi teknistä apua tai antaaksesi palvelua koskevia virheilmoituksia, ole hyvä ja ota yhteyttä www-sivun http://ilmatieteenlaitos.fi/avoin-data kautta.
-        </ows:ContactInstructions>
-      </ows:ContactInfo>
-      <ows:Role>PointOfContact</ows:Role>
-    </ows:ServiceContact>
-<TMPL_else>
   <TMPL_if DEFINED(Capabilities && Capabilities.ServiceIdentification)><ows:ServiceIdentification><TMPL_if DEFINED(Capabilities.ServiceIdentification.Title)>
     <ows:Title><TMPL_var Capabilities.ServiceIdentification.Title></ows:Title></TMPL_if><TMPL_if DEFINED(Capabilities.ServiceIdentification.Abstract)>
-    <ows:Abstract><TMPL_var Capabilities.ServiceIdentification.Abstract>
+    <ows:Abstract>
+      <TMPL_var Capabilities.ServiceIdentification.Abstract>
     </ows:Abstract></TMPL_if><TMPL_if DEFINED(Capabilities.ServiceIdentification.Keywords && Capabilities.ServiceIdentification.Keywords.Keyword)>
     <ows:Keywords><TMPL_foreach Capabilities.ServiceIdentification.Keywords.Keyword as keyword>
-      <ows:Keyword><TMPL_var keyword></ows:Keyword></TMPL_foreach><TMPL_if DEFINED(Capabilities.ServiceIdentification.Keywords.Type)>
+      <ows:Keyword><TMPL_var keyword[0]></ows:Keyword></TMPL_foreach><TMPL_if DEFINED(Capabilities.ServiceIdentification.Keywords.Type)>
       <ows:Type><TMPL_var Capabilities.ServiceIdentification.Keywords.Type></ows:Type></TMPL_if>
     </ows:Keywords></TMPL_if>
     <ows:ServiceType>WCS</ows:ServiceType>
     <ows:ServiceTypeVersion><TMPL_var version></ows:ServiceTypeVersion>
     <ows:Fees><TMPL_if DEFINED(Capabilities.ServiceIdentification.Fees)>
       <TMPL_var Capabilities.ServiceIdentification.Fees></TMPL_if>
-    </ows:Fees><TMPL_if DEFINED(Capabilities.ServiceIdentification.AccessConstraints.eng)>
-    <ows:AccessConstraints><TMPL_var Capabilities.ServiceIdentification.AccessConstraints.eng>
+    </ows:Fees><TMPL_if DEFINED(Capabilities.ServiceIdentification.AccessConstraints)>
+    <ows:AccessConstraints><TMPL_var Capabilities.ServiceIdentification.AccessConstraints>
     </ows:AccessConstraints></TMPL_if>
   </ows:ServiceIdentification></TMPL_if>
   <TMPL_if DEFINED(Capabilities && Capabilities.ServiceProvider && Capabilities.ServiceProvider.ProviderName && Capabilities.ServiceProvider.ServiceContact)><ows:ServiceProvider>
@@ -95,9 +48,9 @@
           <ows:PostalCode><TMPL_var Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.PostalCode></ows:PostalCode></TMPL_if><TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.Country)>
           <ows:Country><TMPL_var Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.Country></ows:Country></TMPL_if><TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.ElectronicMailAddress)>
           <ows:ElectronicMailAddress><TMPL_var Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.ElectronicMailAddress></ows:ElectronicMailAddress></TMPL_if>
-        </ows:Address></TMPL_if><TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.ContactInfo.OnlineResource)>
+        </ows:Address></TMPL_if><TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.ContactInfo.OnlineResource && Capabilities.ServiceProvider.ServiceContact.ContactInfo.OnlineResource.href)>
 
-        <ows:OnlineResource xlink:href="http://en.ilmatieteenlaitos.fi/open-data"/></TMPL_if><TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.ContactInfo.ContactInstructions)>
+        <ows:OnlineResource xlink:href="<TMPL_var Capabilities.ServiceProvider.ServiceContact.ContactInfo.OnlineResource.href>"/></TMPL_if><TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.ContactInfo.ContactInstructions)>
         <ows:ContactInstructions>
 
           <TMPL_var Capabilities.ServiceProvider.ServiceContact.ContactInfo.ContactInstructions>
@@ -106,7 +59,7 @@
       </ows:ContactInfo></TMPL_if>
       <TMPL_if DEFINED(Capabilities.ServiceProvider.ServiceContact.Role)><ows:Role><TMPL_var Capabilities.ServiceProvider.ServiceContact.Role></ows:Role></TMPL_if>
     </ows:ServiceContact>
-  </ows:ServiceProvider></TMPL_if></TMPL_if><TMPL_if DEFINED(operation.GetCapabilities && operation.DescribeCoverage)>
+  </ows:ServiceProvider></TMPL_if><TMPL_comment></TMPL_if></TMPL_comment><TMPL_if DEFINED(operation.GetCapabilities && operation.DescribeCoverage)>
   <ows:OperationsMetadata>
     <ows:Operation name="GetCapabilities">
       <ows:DCP>

--- a/include/ConfigHash.h
+++ b/include/ConfigHash.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "Config.h"
+#include "MultiLanguageString.h"
+
+#include <ctpp2/CDT.hpp>
+#include <spine/ConfigBase.h>
+#include <memory>
+
+namespace SmartMet
+{
+namespace Plugin
+{
+namespace WCS
+{
+class ConfigHash
+{
+ public:
+  using Shared = std::shared_ptr<ConfigHash>;
+  using Unique = std::unique_ptr<ConfigHash>;
+
+  explicit ConfigHash();
+  virtual ~ConfigHash();
+
+  const CTPP::CDT& getHash() const;
+  void set(const libconfig::Config& config);
+  void set(const libconfig::Setting& setting);
+
+  bool exists(const std::string& key);
+
+ private:
+  ConfigHash(const ConfigHash& other) = delete;
+  const ConfigHash& operator=(const ConfigHash& other) = delete;
+
+  void store(const libconfig::Setting& setting, CTPP::CDT& hash);
+
+  CTPP::CDT mHash;
+};
+}
+}
+}

--- a/include/ConfigHash.h
+++ b/include/ConfigHash.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Config.h"
-#include "MultiLanguageString.h"
 
 #include <ctpp2/CDT.hpp>
 #include <spine/ConfigBase.h>
@@ -16,6 +15,7 @@ namespace WCS
 class ConfigHash
 {
  public:
+  using Language = std::string;
   using Shared = std::shared_ptr<ConfigHash>;
   using Unique = std::unique_ptr<ConfigHash>;
 
@@ -25,6 +25,7 @@ class ConfigHash
   const CTPP::CDT& getHash() const;
   void set(const libconfig::Config& config);
   void set(const libconfig::Setting& setting);
+  void setLanguage(const Language& language);
 
   bool exists(const std::string& key);
 
@@ -35,6 +36,7 @@ class ConfigHash
   void store(const libconfig::Setting& setting, CTPP::CDT& hash);
 
   CTPP::CDT mHash;
+  Language mLanguage;
 };
 }
 }

--- a/include/ConfigHash.h
+++ b/include/ConfigHash.h
@@ -20,6 +20,7 @@ class ConfigHash
   using Unique = std::unique_ptr<ConfigHash>;
 
   explicit ConfigHash();
+  explicit ConfigHash(const ConfigHash& other);
   virtual ~ConfigHash();
 
   const CTPP::CDT& getHash() const;
@@ -30,7 +31,6 @@ class ConfigHash
   bool exists(const std::string& key);
 
  private:
-  ConfigHash(const ConfigHash& other) = delete;
   const ConfigHash& operator=(const ConfigHash& other) = delete;
 
   void store(const libconfig::Setting& setting, CTPP::CDT& hash);

--- a/include/ConfigHash.h
+++ b/include/ConfigHash.h
@@ -26,6 +26,9 @@ class ConfigHash
   const CTPP::CDT& getHash() const;
   void set(const libconfig::Config& config);
   void set(const libconfig::Setting& setting);
+
+  // Set language to search from MultiLanguageString setting.
+  void setDefaultLanguage(const Language& language);
   void setLanguage(const Language& language);
 
   bool exists(const std::string& key);
@@ -36,6 +39,7 @@ class ConfigHash
   void store(const libconfig::Setting& setting, CTPP::CDT& hash);
 
   CTPP::CDT mHash;
+  Language mDefaultLanguage;
   Language mLanguage;
 };
 }

--- a/include/ConfigHash.h
+++ b/include/ConfigHash.h
@@ -25,12 +25,13 @@ class ConfigHash
   virtual ~ConfigHash();
 
   const CTPP::CDT& getHash() const;
-  void set(const libconfig::Config& config);
-  void set(const libconfig::Setting& setting);
 
   // Set language to search from MultiLanguageString setting.
   void setDefaultLanguage(const Language& language);
   void setLanguage(const Language& language);
+
+  void process(const libconfig::Config& config);
+  void process(const libconfig::Setting& setting);
 
   bool exists(const Path& path);
 

--- a/include/ConfigHash.h
+++ b/include/ConfigHash.h
@@ -15,6 +15,7 @@ namespace WCS
 class ConfigHash
 {
  public:
+  using Path = std::string;
   using Language = std::string;
   using Shared = std::shared_ptr<ConfigHash>;
   using Unique = std::unique_ptr<ConfigHash>;
@@ -31,7 +32,7 @@ class ConfigHash
   void setDefaultLanguage(const Language& language);
   void setLanguage(const Language& language);
 
-  bool exists(const std::string& key);
+  bool exists(const Path& path);
 
  private:
   const ConfigHash& operator=(const ConfigHash& other) = delete;

--- a/include/ConfigHash.h
+++ b/include/ConfigHash.h
@@ -12,6 +12,8 @@ namespace Plugin
 {
 namespace WCS
 {
+/** \brief Create CTPP::CDT hash from a libconfig configuration.
+ */
 class ConfigHash
 {
  public:
@@ -24,15 +26,43 @@ class ConfigHash
   explicit ConfigHash(const ConfigHash& other);
   virtual ~ConfigHash();
 
+  /** \brief Get the processed result.
+   *  \return Processed configuration or setting as a hash container.
+   */
   const CTPP::CDT& getHash() const;
 
-  // Set language to search from MultiLanguageString setting.
+  /** \brief Set a default language which must be given in every MultiLanguageString group.
+   *  Text mapped to the default language will be used if text to a requested language
+   *  does not exist (setLanguage method). If the default is not set, all the
+   *  MultiLanguageString groups will be ignored as a context of MultiLanguageString class
+   *  and the content will be processed as a normal setting.
+   *  \param[in] language A default language which must be given in MultiLanguageString group.
+   */
   void setDefaultLanguage(const Language& language);
+
+  /** \brief Set a language which will be used in result.
+   *  The language will be used instead of the default when MultiLanguageString groups
+   *  are processed. If a text for the language is not found, the default language will be used.
+   *  \param[in] language The language to favour against the default.
+   */
   void setLanguage(const Language& language);
 
+  /** \brief Process a full configuration
+   *  \param config A full congfiguration.
+   */
   void process(const libconfig::Config& config);
+
+  /** \brief Process a setting which may be a part of the full configuration.
+   *  \param setting A setting in configuration
+   */
   void process(const libconfig::Setting& setting);
 
+  /** \brief Test if a configuration exist in the object.
+   *  Use dot notation for a path e.g. "Capability.ServiceIdentification.Title".
+   *  \param path A path from the root of a config or a setting
+   *  \retval true If every node of the path exists.
+   *  \retval false If some node of the path does not exist.
+   */
   bool exists(const Path& path);
 
  private:

--- a/include/MultiLanguageString.h
+++ b/include/MultiLanguageString.h
@@ -24,7 +24,7 @@ class MultiLanguageString
   using Message = std::string;
   using Content = std::map<Language, Message>;
 
-  MultiLanguageString(const Language& defaultLanguage, libconfig::Setting& setting);
+  MultiLanguageString(const Language& defaultLanguage, const libconfig::Setting& setting);
   virtual ~MultiLanguageString();
   static Shared create(const Language& defaultLanguage, libconfig::Setting& setting);
   const Message& get() const;

--- a/include/PluginData.h
+++ b/include/PluginData.h
@@ -84,6 +84,7 @@ class PluginData : public boost::noncopyable
   void createTemplateFormatters();
   void createXmlParser();
   void createParameterConfigs();
+  void createServiceMetaData();
 
  private:
   Config mConfig;

--- a/include/WcsCapabilities.h
+++ b/include/WcsCapabilities.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ConfigHash.h"
 #include "Coverage.h"
 #include "RequestType.h"
 #include <boost/date_time/posix_time/posix_time.hpp>
@@ -25,6 +26,7 @@ class WcsCapabilities
   using FormatSetMap = std::map<RequestType, FormatSet>;
   using Operation = std::string;
   using OperationSet = std::set<Operation>;
+  using ServiceMetaData = ConfigHash;
   using Version = std::string;
   using VersionSet = std::set<Version>;
 
@@ -43,11 +45,15 @@ class WcsCapabilities
 
   const Version& getHighestVersion() const;
 
+  const ServiceMetaData::Shared& getServiceMetaData() const;
+
   bool registerOperation(const Operation& operation);
 
   bool registerOutputFormat(const RequestType& rtype, const Format& format);
 
   void registerDataset(const Dataset& code, const CoverageDescription& cov);
+
+  void setServiceMetaData(const ServiceMetaData::Shared& serviceMetaData);
 
  private:
   FormatSetMap mFormats;
@@ -55,6 +61,7 @@ class WcsCapabilities
   VersionSet mVersions;
   Version mHighestVersion;
   DatasetMap mDatasetMap;
+  ServiceMetaData::Shared mServiceMetaData;
 
   /**
    *  @brief Mutex for preventing race conditions when accessing this object

--- a/include/WcsCapabilities.h
+++ b/include/WcsCapabilities.h
@@ -24,9 +24,11 @@ class WcsCapabilities
   using Format = std::string;
   using FormatSet = std::set<Format>;
   using FormatSetMap = std::map<RequestType, FormatSet>;
+  using Language = std::string;
   using Operation = std::string;
   using OperationSet = std::set<Operation>;
   using ServiceMetaData = ConfigHash;
+  using ServiceMetaDataMap = std::map<Language, ServiceMetaData>;
   using Version = std::string;
   using VersionSet = std::set<Version>;
 
@@ -45,7 +47,7 @@ class WcsCapabilities
 
   const Version& getHighestVersion() const;
 
-  const ServiceMetaData::Shared& getServiceMetaData() const;
+  const ServiceMetaData::Shared getServiceMetaData(const Language& language) const;
 
   bool registerOperation(const Operation& operation);
 
@@ -53,7 +55,7 @@ class WcsCapabilities
 
   void registerDataset(const Dataset& code, const CoverageDescription& cov);
 
-  void setServiceMetaData(const ServiceMetaData::Shared& serviceMetaData);
+  void registerServiceMetaData(const Language& language, const ServiceMetaData& serviceMetaData);
 
  private:
   FormatSetMap mFormats;
@@ -61,7 +63,7 @@ class WcsCapabilities
   VersionSet mVersions;
   Version mHighestVersion;
   DatasetMap mDatasetMap;
-  ServiceMetaData::Shared mServiceMetaData;
+  ServiceMetaDataMap mServiceMetaData;
 
   /**
    *  @brief Mutex for preventing race conditions when accessing this object

--- a/source/ConfigHash.cpp
+++ b/source/ConfigHash.cpp
@@ -8,11 +8,12 @@ namespace Plugin
 {
 namespace WCS
 {
-ConfigHash::ConfigHash() : mHash(CTPP::CDT()), mLanguage("")
+ConfigHash::ConfigHash() : mHash(CTPP::CDT()), mDefaultLanguage(""), mLanguage("")
 {
 }
 
-ConfigHash::ConfigHash(const ConfigHash& other) : mHash(other.getHash()), mLanguage(other.mLanguage)
+ConfigHash::ConfigHash(const ConfigHash& other)
+    : mHash(other.getHash()), mDefaultLanguage(other.mDefaultLanguage), mLanguage(other.mLanguage)
 {
 }
 
@@ -72,6 +73,11 @@ void ConfigHash::set(const libconfig::Setting& setting)
   }
 }
 
+void ConfigHash::setDefaultLanguage(const Language& language)
+{
+  mDefaultLanguage = language;
+}
+
 void ConfigHash::setLanguage(const Language& language)
 {
   mLanguage = language;
@@ -86,14 +92,15 @@ void ConfigHash::store(const libconfig::Setting& setting, CTPP::CDT& targetHash)
 
     if (type == libconfig::Setting::TypeGroup)
     {
-      if (name and not mLanguage.empty() and std::string(name) == "MultiLanguageString")
+      int N = setting.getLength();
+      if (name and N > 0 and not mDefaultLanguage.empty() and
+          std::string(name) == "MultiLanguageString")
       {
-        MultiLanguageString mlString(mLanguage, setting);
-        targetHash = mlString.get();
+        MultiLanguageString mlString(mDefaultLanguage, setting);
+        targetHash = mlString.get(mLanguage);
       }
       else
       {
-        int N = setting.getLength();
         for (int i = 0; i < N; i++)
         {
           if (name)

--- a/source/ConfigHash.cpp
+++ b/source/ConfigHash.cpp
@@ -1,0 +1,172 @@
+#include "ConfigHash.h"
+
+#include "WcsException.h"
+
+namespace SmartMet
+{
+namespace Plugin
+{
+namespace WCS
+{
+ConfigHash::ConfigHash() : mHash(CTPP::CDT())
+{
+}
+
+ConfigHash::~ConfigHash()
+{
+}
+
+const CTPP::CDT& ConfigHash::getHash() const
+{
+  return mHash;
+}
+
+bool ConfigHash::exists(const std::string& key)
+{
+  try
+  {
+    if (mHash.Exists(key))
+      return true;
+
+    return false;
+  }
+  catch (const CTPP::CTPPException& err)
+  {
+    throw Spine::Exception(BCP, err.what(), NULL);
+  }
+  catch (...)
+  {
+    throw Spine::Exception(BCP, "Unknown error while trying to find a key from hash", NULL);
+  }
+}
+
+void ConfigHash::set(const libconfig::Config& config)
+{
+  try
+  {
+    // Clear the old data and store the new one.
+    libconfig::Setting& root = config.getRoot();
+    mHash = CTPP::CDT();
+    store(root, mHash);
+  }
+  catch (...)
+  {
+    throw SmartMet::Spine::Exception(BCP, "Config set to ConfigHash failed!", NULL);
+  }
+}
+
+void ConfigHash::set(const libconfig::Setting& setting)
+{
+  try
+  {
+    mHash = CTPP::CDT();
+    store(setting, mHash);
+  }
+  catch (...)
+  {
+    throw SmartMet::Spine::Exception(BCP, "Setting set to ConfigHash failed!", NULL);
+  }
+}
+
+void ConfigHash::store(const libconfig::Setting& setting, CTPP::CDT& targetHash)
+{
+  try
+  {
+    const char* name = setting.getName();
+    int type = setting.getType();
+
+    if (type == libconfig::Setting::TypeGroup)
+    {
+      int N = setting.getLength();
+      for (int i = 0; i < N; i++)
+      {
+        if (name)
+          store(setting[i], targetHash[name]);
+        else
+          store(setting[i], targetHash[i]);
+      }
+    }
+    else if (type == libconfig::Setting::TypeList)
+    {
+      int N = setting.getLength();
+      for (int i = 0; i < N; i++)
+      {
+        if (name)
+          store(setting[i], targetHash[name][i]);
+        else
+          store(setting[i], targetHash[i]);
+      }
+    }
+    else if (type == libconfig::Setting::TypeArray)
+    {
+      int N = setting.getLength();
+      for (int i = 0; i < N; i++)
+      {
+        if (name)
+          store(setting[i], targetHash[name][i]);
+        else
+          store(setting[i], targetHash[i]);
+      }
+    }
+    else if (type == libconfig::Setting::TypeInt)
+    {
+      int value = setting;
+      if (name)
+        targetHash[name] = value;
+      else
+        targetHash = value;
+    }
+    else if (type == libconfig::Setting::TypeInt64)
+    {
+      int64_t value = setting;
+      if (name)
+        targetHash[name] = value;
+      else
+        targetHash = value;
+    }
+    else if (type == libconfig::Setting::TypeFloat)
+    {
+      double value = setting;
+      char buffer[80];
+      snprintf(buffer, sizeof(buffer), "%.16g", value);
+      if (name)
+        targetHash[name] = buffer;
+      else
+        targetHash = buffer;
+    }
+    else if (type == libconfig::Setting::TypeString)
+    {
+      const std::string value = setting;
+      if (name)
+        targetHash[name] = value;
+      else
+        targetHash = value;
+    }
+    else if (type == libconfig::Setting::TypeBoolean)
+    {
+      const bool value = setting;
+      if (name)
+        targetHash[name] = (value ? "true" : "false");
+      else
+        targetHash = (value ? "true" : "false");
+    }
+    else
+    {
+      // Error: unknown type
+      targetHash[0] = '?';
+    }
+  }
+  catch (...)
+  {
+    std::ostringstream msg;
+    msg << "ConfigHash  failed. "
+        << "Setting type: '" << setting.getType() << "' ";
+    if (const char* name = setting.getName())
+      msg << " name: '" << name << "'.";
+
+    throw SmartMet::Spine::Exception(BCP, msg.str(), NULL);
+  }
+}
+}
+}
+}

--- a/source/ConfigHash.cpp
+++ b/source/ConfigHash.cpp
@@ -1,5 +1,5 @@
 #include "ConfigHash.h"
-
+#include "MultiLanguageString.h"
 #include "WcsException.h"
 
 namespace SmartMet
@@ -8,7 +8,7 @@ namespace Plugin
 {
 namespace WCS
 {
-ConfigHash::ConfigHash() : mHash(CTPP::CDT())
+ConfigHash::ConfigHash() : mHash(CTPP::CDT()), mLanguage("")
 {
 }
 
@@ -68,6 +68,11 @@ void ConfigHash::set(const libconfig::Setting& setting)
   }
 }
 
+void ConfigHash::setLanguage(const Language& language)
+{
+  mLanguage = language;
+}
+
 void ConfigHash::store(const libconfig::Setting& setting, CTPP::CDT& targetHash)
 {
   try
@@ -77,13 +82,21 @@ void ConfigHash::store(const libconfig::Setting& setting, CTPP::CDT& targetHash)
 
     if (type == libconfig::Setting::TypeGroup)
     {
-      int N = setting.getLength();
-      for (int i = 0; i < N; i++)
+      if (name and not mLanguage.empty() and std::string(name) == "MultiLanguageString")
       {
-        if (name)
-          store(setting[i], targetHash[name]);
-        else
-          store(setting[i], targetHash[i]);
+        MultiLanguageString mlString(mLanguage, setting);
+        targetHash = mlString.get();
+      }
+      else
+      {
+        int N = setting.getLength();
+        for (int i = 0; i < N; i++)
+        {
+          if (name)
+            store(setting[i], targetHash[name]);
+          else
+            store(setting[i], targetHash[i]);
+        }
       }
     }
     else if (type == libconfig::Setting::TypeList)

--- a/source/ConfigHash.cpp
+++ b/source/ConfigHash.cpp
@@ -12,6 +12,10 @@ ConfigHash::ConfigHash() : mHash(CTPP::CDT()), mLanguage("")
 {
 }
 
+ConfigHash::ConfigHash(const ConfigHash& other) : mHash(other.getHash()), mLanguage(other.mLanguage)
+{
+}
+
 ConfigHash::~ConfigHash()
 {
 }

--- a/source/ConfigHash.cpp
+++ b/source/ConfigHash.cpp
@@ -2,6 +2,8 @@
 #include "MultiLanguageString.h"
 #include "WcsException.h"
 
+#include <boost/algorithm/string.hpp>
+
 namespace SmartMet
 {
 namespace Plugin
@@ -26,14 +28,23 @@ const CTPP::CDT& ConfigHash::getHash() const
   return mHash;
 }
 
-bool ConfigHash::exists(const std::string& key)
+bool ConfigHash::exists(const Path& path)
 {
   try
   {
-    if (mHash.Exists(key))
-      return true;
+    std::vector<Path> keys;
+    boost::algorithm::split(keys, path, boost::algorithm::is_any_of("."));
 
-    return false;
+    CTPP::CDT& existedCDT = mHash;
+    bool bCDTExist = false;
+    for (auto item : keys)
+    {
+      existedCDT = existedCDT.GetExistedCDT(item, bCDTExist);
+      if (not bCDTExist)
+        return false;
+    }
+
+    return true;
   }
   catch (const CTPP::CTPPException& err)
   {
@@ -41,7 +52,7 @@ bool ConfigHash::exists(const std::string& key)
   }
   catch (...)
   {
-    throw Spine::Exception(BCP, "Unknown error while trying to find a key from hash", NULL);
+    throw Spine::Exception(BCP, "Unknown error while trying to find a path from hash", NULL);
   }
 }
 

--- a/source/ConfigHash.cpp
+++ b/source/ConfigHash.cpp
@@ -56,7 +56,7 @@ bool ConfigHash::exists(const Path& path)
   }
 }
 
-void ConfigHash::set(const libconfig::Config& config)
+void ConfigHash::process(const libconfig::Config& config)
 {
   try
   {
@@ -71,7 +71,7 @@ void ConfigHash::set(const libconfig::Config& config)
   }
 }
 
-void ConfigHash::set(const libconfig::Setting& setting)
+void ConfigHash::process(const libconfig::Setting& setting)
 {
   try
   {

--- a/source/MultiLanguageString.cpp
+++ b/source/MultiLanguageString.cpp
@@ -12,7 +12,7 @@ namespace Plugin
 namespace WCS
 {
 MultiLanguageString::MultiLanguageString(const Language& defaultLanguage,
-                                         libconfig::Setting& setting)
+                                         const libconfig::Setting& setting)
     : mDefaultLanguage(Fmi::ascii_tolower_copy(defaultLanguage)), mData()
 {
   try

--- a/source/PluginData.cpp
+++ b/source/PluginData.cpp
@@ -149,7 +149,7 @@ void PluginData::createServiceMetaData()
         WcsCapabilities::ServiceMetaData serviceMetaData;
         serviceMetaData.setDefaultLanguage(defaultLanguage);
         serviceMetaData.setLanguage(language);
-        serviceMetaData.set(*setting);
+        serviceMetaData.process(*setting);
         mWcsCapabilities->registerServiceMetaData(language, serviceMetaData);
       }
 

--- a/source/PluginData.cpp
+++ b/source/PluginData.cpp
@@ -140,10 +140,12 @@ void PluginData::createServiceMetaData()
     if (setting)
     {
       WcsCapabilities::ServiceMetaDataMap metaDataMap;
+      const auto &defaultLanguage = getLanguages().at(0);
 
       for (auto language : getLanguages())
       {
         WcsCapabilities::ServiceMetaData serviceMetaData;
+        serviceMetaData.setDefaultLanguage(defaultLanguage);
         serviceMetaData.setLanguage(language);
         serviceMetaData.set(*setting);
         mWcsCapabilities->registerServiceMetaData(language, serviceMetaData);

--- a/source/PluginData.cpp
+++ b/source/PluginData.cpp
@@ -1,7 +1,9 @@
 #include "PluginData.h"
 #include "WcsException.h"
+
 #include <macgyver/StringConversion.h>
 #include <macgyver/TimeParser.h>
+#include <functional>
 
 namespace SmartMet
 {
@@ -149,6 +151,48 @@ void PluginData::createServiceMetaData()
         serviceMetaData.setLanguage(language);
         serviceMetaData.set(*setting);
         mWcsCapabilities->registerServiceMetaData(language, serviceMetaData);
+      }
+
+      std::vector<WcsCapabilities::ServiceMetaData::Path> settingsRequired = {
+          "Capabilities.ServiceIdentification.Title",
+          "Capabilities.ServiceIdentification.Abstract",
+          "Capabilities.ServiceIdentification.Keywords",
+          "Capabilities.ServiceIdentification.Keywords.Keyword",
+          "Capabilities.ServiceIdentification.ServiceType",
+          "Capabilities.ServiceIdentification.Fees",
+          "Capabilities.ServiceIdentification.AccessConstraints",
+          "Capabilities.ServiceProvider.ProviderName",
+          "Capabilities.ServiceProvider.ProviderSite",
+          "Capabilities.ServiceProvider.ProviderSite.href",
+          "Capabilities.ServiceProvider.ServiceContact",
+          "Capabilities.ServiceProvider.ServiceContact.ContactInfo",
+          "Capabilities.ServiceProvider.ServiceContact.ContactInfo.Phone",
+          "Capabilities.ServiceProvider.ServiceContact.ContactInfo.Phone.Voice",
+          "Capabilities.ServiceProvider.ServiceContact.ContactInfo.Phone.Facsimile",
+          "Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address",
+          "Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.DeliveryPoint",
+          "Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.City",
+          "Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.AdministrativeArea",
+          "Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.PostalCode",
+          "Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.Country",
+          "Capabilities.ServiceProvider.ServiceContact.ContactInfo.Address.ElectronicMailAddress",
+          "Capabilities.ServiceProvider.ServiceContact.ContactInfo.OnlineResource",
+          "Capabilities.ServiceProvider.ServiceContact.ContactInfo.OnlineResource.href",
+          "Capabilities.ServiceProvider.ServiceContact.ContactInfo.ContactInstructions",
+          "Capabilities.ServiceProvider.ServiceContact.Role"};
+
+      for (const auto &path : settingsRequired)
+      {
+        if (not mWcsCapabilities->getServiceMetaData(defaultLanguage)->exists(path))
+        {
+          std::ostringstream msg;
+          msg << "Configuration '" << path
+              << "' not found from the main configurations. Following setting required: \n";
+          for (const auto &item : settingsRequired)
+            msg << item << "\n";
+
+          throw WcsException(WcsException::NO_APPLICABLE_CODE, msg.str());
+        }
       }
     }
   }

--- a/source/PluginData.cpp
+++ b/source/PluginData.cpp
@@ -139,10 +139,15 @@ void PluginData::createServiceMetaData()
     libconfig::Setting *setting = mConfig.find_setting(mConfig.get_root(), "Capabilities", false);
     if (setting)
     {
-      WcsCapabilities::ServiceMetaData::Shared serviceMetaData(
-          new WcsCapabilities::ServiceMetaData);
-      serviceMetaData->set(*setting);
-      mWcsCapabilities->setServiceMetaData(serviceMetaData);
+      WcsCapabilities::ServiceMetaDataMap metaDataMap;
+
+      for (auto language : getLanguages())
+      {
+        WcsCapabilities::ServiceMetaData serviceMetaData;
+        serviceMetaData.setLanguage(language);
+        serviceMetaData.set(*setting);
+        mWcsCapabilities->registerServiceMetaData(language, serviceMetaData);
+      }
     }
   }
   catch (const std::exception &exception)

--- a/source/WcsCapabilities.cpp
+++ b/source/WcsCapabilities.cpp
@@ -13,7 +13,10 @@ namespace WCS
 {
 using SmartMet::Spine::log_time_str;
 
-WcsCapabilities::WcsCapabilities() : mVersions({"2.0.1", "2.0.0"}), mHighestVersion("2.0.1")
+WcsCapabilities::WcsCapabilities()
+    : mVersions({"2.0.1", "2.0.0"}),
+      mHighestVersion("2.0.1"),
+      mServiceMetaData(new ServiceMetaData())
 {
   if (mVersions.empty() or mHighestVersion.empty())
   {
@@ -102,6 +105,12 @@ const WcsCapabilities::Version& WcsCapabilities::getHighestVersion() const
   return mHighestVersion;
 }
 
+const WcsCapabilities::ServiceMetaData::Shared& WcsCapabilities::getServiceMetaData() const
+{
+  Spine::ReadLock lock(mutex);
+  return mServiceMetaData;
+}
+
 void WcsCapabilities::registerDataset(const WcsCapabilities::Dataset& code,
                                       const CoverageDescription& cov)
 {
@@ -118,6 +127,12 @@ const WcsCapabilities::DatasetMap& WcsCapabilities::getSupportedDatasets() const
 {
   Spine::ReadLock lock(mutex);
   return mDatasetMap;
+}
+
+void WcsCapabilities::setServiceMetaData(const ServiceMetaData::Shared& serviceMetaData)
+{
+  Spine::WriteLock lock(mutex);
+  mServiceMetaData = serviceMetaData;
 }
 }
 }

--- a/source/request/GetCapabilities.cpp
+++ b/source/request/GetCapabilities.cpp
@@ -127,6 +127,10 @@ void GetCapabilities::execute(std::ostream& output) const
     }
   }
 
+  auto metadataHash = capabilities.getServiceMetaData()->getHash();
+  if (metadataHash.Size() > 0)
+    hash.MergeCDT(metadataHash);
+
   std::ostringstream logMessages;
   try
   {

--- a/source/request/GetCapabilities.cpp
+++ b/source/request/GetCapabilities.cpp
@@ -127,7 +127,7 @@ void GetCapabilities::execute(std::ostream& output) const
     }
   }
 
-  auto metadataHash = capabilities.getServiceMetaData()->getHash();
+  auto metadataHash = capabilities.getServiceMetaData(language)->getHash();
   if (metadataHash.Size() > 0)
     hash.MergeCDT(metadataHash);
 

--- a/test/base/cnf/wcs_plugin_test.conf
+++ b/test/base/cnf/wcs_plugin_test.conf
@@ -22,3 +22,218 @@ supportedCRSs =
 "http://www.opengis.net/def/crs/EPSG/0/4258",
 "http://www.opengis.net/def/crs/EPSG/0/4326"
 ];
+
+
+Capabilities:
+{
+ServiceIdentification:
+{
+  Title: "Finnish Meteorological Institute's Open Data Download Service";
+  Abstract: "
+      Finnish Meteorological Institute's Open Data Download Service provides data
+      free-of-charge for public use. The producer of open data is the Finnish
+      Meteorological Institute.";
+
+  Keywords:
+  {
+    Keyword: ( "Forecast", "Model", "Hirlam" );
+    Type: "String";
+  };
+
+  ServiceType: "WCS";
+
+  Fees: "The use of this service and the returned data is free-of-charge, but users must
+      register and agree to the terms of service to gain access to the data.";
+
+  AccessConstraints:
+  {
+    eng: "
+
+
+1.7.2014
+
+1. General
+The use of the material is governed by the terms and conditions specified in this licence.
+
+The following are regarded as the producer of open data and the holders of copyright or database rights: the Finnish Meteorological Institute, the Finnish Transport Agency and other data producers as specified in Annex 1 (hereinafter the licensors).
+
+When used, the material or the service including or utilising the material must be accompanied by information on the original source and the date of the current version as follows:
+- the producer of the material and the retrieval date;
+- a note if the data have been adapted.
+
+The licensee refers to a natural or legal person who takes the material covered by this licence into use.
+
+The licensor does not charge a fee for using the material subject to this licence.
+
+By receiving the material, the licensee accepts the terms of this licence.
+
+2. Terms of use
+
+2.1. The right to use the material
+This licence grants a worldwide, free of charge, perpetual, non-exclusive right, under which the material received by the licensee can be freely:
+- copied, distributed and published;
+- adapted and utilised commercially and non-commercially;
+- combined with other products; and
+- used as part of an application or a service.
+
+2.2. The licensee's obligations and responsibilities
+When using and transmitting the material or products made of the material, the licensee must:
+
+- mention the original source of the material in accordance with Section 1. General;
+- present a copy of this licence or a link to it;
+- require that the attribution practice specified under Section 1. General of this licence is followed when the licensee grants licenses to a product or service that uses some or all of the material subject to this licence;
+remove the note of the original source if so required explicitly by the licensor.
+- Special additional terms as stated in Annex 2 apply to aviation weather reports (METAR).
+
+This licence does not create any cooperation or business relationship between the licensee and the licensor. In connection with the material, the licensee must not indicate that the licensor endorses or recommends the licensee's use of the material.
+
+Malicious use of the download service maintained by the licensor is prohibited.
+
+2.3. The licensor's obligations and responsibilities
+The licensor is responsible for ensuring that it has the right to grant a licence to the material specified in Section 1. General.
+
+The material is licensed ‘as is' and the licensor is not liable for decisions made on the basis of the material, for any errors in the material, or for direct or indirect damage caused by the use of the material. The licensor does not grant any warranty for the material and does not guarantee that the material is accurate and up-to-date.
+
+The licensor does not guarantee that the material is constantly available, and the licensor may terminate the distribution of the material without prior notice. The licensor may also change the interface for downloading the material without prior notice.
+
+3. Applicable law
+This licence is governed by Finnish law.
+
+4. Changes to this licence
+At any time, the licensor may change the licence terms or may apply a different licence to the material. However, the terms of this licence continue to be applied to individual materials that had already been downloaded when the licence changed.
+
+ANNEX 1
+
+Other data producers
+(No other data producers.)
+
+ANNEX 2
+
+Additional terms for aviation weather reports (METAR)
+
+GENERAL ASPECTS
+
+The airports produce two different kinds of weather reports: aviation weather reports (METAR) and weather observations. Aviation weather reports (METAR) are generally compiled from the data collected by the airport's various observation equipment in compliance with the regulations in ICAO Annex 3*. Weather observations refer to data collected by certain observation equipment at an airport. Due to different calculation methods and deduction chains, the differences between an aviation weather report (METAR) and a weather observation at an aerodrome can be quite large.
+
+The Finnish Meteorological Institute has been appointed as the designated producer of aviation weather reports in the Finnish Flight Information Region until 31 January 2010 (Decision of the Finnish Ministry of Transport and Communications, 5 March 2013, record number LVM/1185/02/2012).
+
+ICAO Annex 3* establishes specific formal and material requirements for METAR weather reports.
+
+RECOMMENDED DISCLAIMER
+Applications containing aviation weather reports (METAR) should contain the following disclaimer: \"METAR reports may be missing or available later than in the Aeronautical Fixed Telecommunication Network (AFTN)\"
+
+*Annex 3 to the Convention on International Civil Aviation – Meteorological Service for International Service for International Air Navigation
+
+";
+
+  fin: "
+1.7.2014
+
+1. Yleistä
+Aineiston käyttöoikeutta rajoittavat tämän lisenssin mukaiset käyttöehdot:
+
+Avoin data -aineiston tuottaja ja tekijänoikeuden tai tietokantasuojan haltijat ovat kukin oman aineistonsa osalta seuraavat: Ilmatieteen laitos, Liikennevirasto ja muut tiedontuottajat (jäljempänä lisenssin myöntäjä). Muut tiedontuottajat on lueteltu liitteessä 1.
+
+Aineistoa käyttäessä on aineiston tai sitä sisältävän tai hyödyntävän palvelun yhteyteen liitettävä maininta alkuperäislähteestä ja aineistoversion ajankohdasta seuraavasti:
+- aineiston tuottaja ja hakuajankohdan päiväys
+- ilmoitus mikäli aineistoa on muokattu
+
+
+Lisenssin saajalla tarkoitetaan luonnollista tai juridista henkilöä, joka ottaa tämän lisenssin alaisen aineiston käyttöön.
+
+Lisenssin myöntäjä ei peri lisenssin alaisen aineiston käytöstä maksua.
+
+Vastaanottamalla aineistoa lisenssin saaja hyväksyy tämän lisenssin ehdot.
+
+2. Lisenssin ehdot
+2.1. Käyttöoikeudet
+Tämä on maailmanlaajuisen, maksuttoman, peruuttamattoman rinnakkaisen käyttöoikeuden myöntävä lisenssi, jonka mukaan lisenssin saajan vastaanottamaa aineistoa voi vapaasti:
+- kopioida, levittää ja julkaista,
+- muokata ja hyödyntää kaupallisesti ja ei-kaupallisesti,
+- yhdistellä muihin tuotteisiin ja
+- käyttää osana sovellusta tai palvelua.
+
+2.2. Lisenssin saajan velvollisuudet ja vastuut
+Lisenssin saajan on aineistoa tai siitä tehtyjä tuotteita käyttäessään ja edelleen luovuttaessaan:
+- mainittava aineiston alkuperäislähde kohdan 1. Yleistä mukaisesti.
+- esitettävä tämän lisenssin kopio tai linkki siihen.
+- vaadittava tämän lisenssin kohdan 1. Yleistä mukaista nimeämiskäytännön noudattamista myöntäessään lisenssejä tuotteeseen tai palveluun, jossa käyttää tämän lisenssin alaista aineistoa tai sen osaa.
+poistettava maininta alkuperäislähteestä, mikäli lisenssin myöntäjä sitä erikseen vaatii.
+- lentosäähavaintosanomiin (METAR) sovelletaan oheisen liitteen 2 mukaisia lisäehtoja.
+
+Lisenssin saajan ja lisenssin myöntäjän välille ei tämän lisenssin myötä synny yhteistyö- tai liikesuhdetta. Lisenssin saaja ei saa aineiston yhteydessä ilmaista, että lisenssin myöntäjä tukisi tai suosittelisi kyseistä aineiston käyttötapaa.
+
+Lisenssin myöntäjän ylläpitämän aineiston latauspalvelun häiriökäyttö on kielletty.
+
+2.3. Lisenssin myöntäjän velvollisuudet ja vastuut
+Lisenssin myöntäjä vastaa, että sillä on oikeus luovuttaa lisenssi kohdassa 1. Yleistä nimettyyn aineistoon.
+
+Aineisto on lisensoitu sellaisenaan eikä lisenssin myöntäjä vastaa aineiston perusteella tehdyistä päätöksistä, aineistossa mahdollisesti esiintyvistä virheistä eikä aineiston käytöstä aiheutuvista välittömistä tai välillisistä vahingoista. Lisenssin myöntäjä ei myönnä aineistolle tai siinä olevien tietojen oikeellisuudelle tai ajantasaisuudelle takuuta.
+
+Lisenssin myöntäjä ei takaa, että aineisto olisi jatkuvasti saatavilla, ja lisenssin myöntäjä voi lopettaa aineiston jakelun ennalta ilmoittamatta. Lisenssin myöntäjä voi myös muuttaa aineiston latausrajapintaa ennalta ilmoittamatta.
+
+3. Sovellettava laki
+Tähän lisenssiin sovelletaan Suomen lakia.
+
+4. Muutokset tähän lisenssiin
+Lisenssin myöntäjä voi milloin tahansa muuttaa lisenssin ehtoja tai soveltaa aineistoon eri lisenssiä. Tämän lisenssin ehtoja sovelletaan kuitenkin edelleen niihin yksittäisiin aineistoihin, jotka oli lisenssin muuttuessa jo ladattu.
+
+
+LIITE 1
+
+Muut tiedontuottajat
+(Toistaiseksi ei muita tiedontuottajia.)
+
+LIITE 2
+
+Lentosäähavaintosanomat (METAR) -aineistoon liittyvät lisäehdot
+
+YLEISTÄ
+Lentokentillä tuotetaan kahta eri säähavaintoaineistoa: lentosäähavaintosanomia (METAReita) ja hetkellisiä säähavaintoja. Lentosäähavaintosanomat (METARit) koostetaan yleensä lentokentän eri havaintolaitteiden datasta noudattaen ICAO Annex 3:n* määräyksiä. Hetkelliset säähavainnot ovat puolestaan lentokentän tiettyjen havaintolaitteiden havaintoja. Lentosäähavaintosanoman (METARin) ja lentopaikan hetkellisen säähavainnon välillä voi olla suuriakin eroja johtuen erilaisista laskentamenetelmistä ja päättelyketjuista.
+
+Ilmatieteen laitos on nimetty yksinoikeudella lentosäähavaintopalveluiden tarjoajaksi Suomen lentotiedotusalueelle 31.1.2020 asti. (LVM päätös 5.3.2013 dnro LVM/1185/02/2012)
+
+ICAO Annex 3:n* mukaan METAR tulee esittää määritetyn muotoisena ja sisältöisenä säähavaintosanomana.
+
+DISCLAIMER -SUOSITUS
+Sovelluksissa, joissa käytetään lentosäähavaintosanomia (METAReita), tulisi esittää disclaimer \"Palvelussa esitetyt METAR-sanomat voivat puuttua tai olla käytettävissä myöhemmin kuin ilmailun viestiverkossa.\"
+
+*Annex 3 to the Convention on International Civil Aviation – Meteorological Service for International Service for International Air Navigation
+";
+  }
+};
+ServiceProvider:
+{
+  ProviderName: "Finnish Meteorological Institute";
+  ProviderSite:
+  {
+    href: "http://en.ilmatieteenlaitos.fi";
+  };
+  ServiceContact:
+  {
+    ContactInfo:
+    {
+      Phone:
+      {
+        Voice: "+358 29 539 1000";
+        Facsimile: "+358 29 539 2303";
+      };
+      Address:
+      {
+        DeliveryPoint: "P.O. BOX 503";
+        City: "Helsinki";
+        AdministrativeArea: "Uusimaa";
+        PostalCode: "00101";
+        Country: "Finland";
+        ElectronicMailAddress: "avoin-data@fmi.fi";
+      };
+      OnlineResource:
+      {
+        href: "http://en.ilmatieteenlaitos.fi/open-data";
+      };
+      ContactInstructions: "For technical help or error reports considering FMI Open Data Web Services, please consult our web page http://en.ilmatieteenlaitos.fi/open-data";
+    };
+    Role: "PointOfContact";
+  };
+};
+}

--- a/test/base/cnf/wcs_plugin_test.conf
+++ b/test/base/cnf/wcs_plugin_test.conf
@@ -28,25 +28,74 @@ Capabilities:
 {
 ServiceIdentification:
 {
-  Title: "Finnish Meteorological Institute's Open Data Download Service";
-  Abstract: "
-      Finnish Meteorological Institute's Open Data Download Service provides data
+  Title:
+  {
+    MultiLanguageString:
+    {
+      eng: "Finnish Meteorological Institute's Open Data Download Service";
+      fin: "Ilmatieteen laitoksen avoimen datan latauspalvelu";
+    };
+  };
+
+  Abstract:
+  {
+    MultiLanguageString:
+    {
+      eng: "Finnish Meteorological Institute's Open Data Download Service provides data
       free-of-charge for public use. The producer of open data is the Finnish
       Meteorological Institute.";
+      fin: "Ilmatieteen laitoksen avoimen datan latauspalvelussa on saatavilla tietoaineistoja
+      maksutta julkisen käyttöön. Tietoaineistoja latauspalveluun tuottavat Ilmatieteen
+      laitos.";
+    };
+  };
 
   Keywords:
   {
-    Keyword: ( "Forecast", "Model", "Hirlam" );
+    Keyword:
+    (
+      {
+        MultiLanguageString:
+        {
+          eng: "Forecast";
+          fin: "Ennuste";
+        };
+      },
+      {
+        MultiLanguageString:
+        {
+          eng: "Model";
+          fin: "Ennustemalli";
+        };
+      },
+      {
+        MultiLanguageString:
+        {
+          eng: "Hirlam";
+          fin: "Hirlam";
+        };
+      }
+    );
     Type: "String";
   };
 
   ServiceType: "WCS";
 
-  Fees: "The use of this service and the returned data is free-of-charge, but users must
+  Fees:
+  {
+    MultiLanguageString:
+    {
+      eng: "The use of this service and the returned data is free-of-charge, but users must
       register and agree to the terms of service to gain access to the data.";
+      fin: "Tämän palvelun käyttö sekä palvelusta ladattu data on maksutonta, mutta käyttäjien
+      tulee rekisteröityä palveluun sekä hyväksyä käyttöehdot saadakseen pääsyn palveluun.";
+    };
+  };
 
   AccessConstraints:
   {
+    MultiLanguageString:
+    {
     eng: "
 
 
@@ -127,6 +176,8 @@ Applications containing aviation weather reports (METAR) should contain the foll
 ";
 
   fin: "
+
+
 1.7.2014
 
 1. Yleistä
@@ -199,15 +250,32 @@ DISCLAIMER -SUOSITUS
 Sovelluksissa, joissa käytetään lentosäähavaintosanomia (METAReita), tulisi esittää disclaimer \"Palvelussa esitetyt METAR-sanomat voivat puuttua tai olla käytettävissä myöhemmin kuin ilmailun viestiverkossa.\"
 
 *Annex 3 to the Convention on International Civil Aviation – Meteorological Service for International Service for International Air Navigation
+
 ";
+  }
   }
 };
 ServiceProvider:
 {
-  ProviderName: "Finnish Meteorological Institute";
+  ProviderName:
+  {
+    MultiLanguageString:
+    {
+      eng: "Finnish Meteorological Institute";
+      fin: "Ilmatieteen laitos";
+    };
+  };
+
   ProviderSite:
   {
-    href: "http://en.ilmatieteenlaitos.fi";
+    href:
+    {
+      MultiLanguageString:
+      {
+        eng: "http://en.ilmatieteenlaitos.fi";
+        fin: "http://ilmatieteenlaitos.fi";
+      };
+    };
   };
   ServiceContact:
   {
@@ -220,18 +288,46 @@ ServiceProvider:
       };
       Address:
       {
-        DeliveryPoint: "P.O. BOX 503";
+        DeliveryPoint:
+        {
+          MultiLanguageString:
+          {
+            eng: "P.O. BOX 503";
+            fin: "PL 503";
+          };
+        };
         City: "Helsinki";
         AdministrativeArea: "Uusimaa";
         PostalCode: "00101";
-        Country: "Finland";
+        Country:
+        {
+          MultiLanguageString:
+          {
+            eng: "Finland";
+            fin: "Suomi";
+          };
+        };
         ElectronicMailAddress: "avoin-data@fmi.fi";
       };
       OnlineResource:
       {
-        href: "http://en.ilmatieteenlaitos.fi/open-data";
+        href:
+        {
+          MultiLanguageString:
+          {
+            eng: "http://en.ilmatieteenlaitos.fi/open-data";
+            fin: "http://ilmatieteenlaitos.fi/avoin-data";
+          };
+        };
       };
-      ContactInstructions: "For technical help or error reports considering FMI Open Data Web Services, please consult our web page http://en.ilmatieteenlaitos.fi/open-data";
+      ContactInstructions:
+      {
+        MultiLanguageString:
+        {
+          eng: "For technical help or error reports considering FMI Open Data Web Services, please consult our web page http://en.ilmatieteenlaitos.fi/open-data";
+          fin: "Saadaksesi teknistä apua tai antaaksesi palvelua koskevia virheilmoituksia, ole hyvä ja ota yhteyttä www-sivun http://ilmatieteenlaitos.fi/avoin-data kautta.";
+        };
+      };
     };
     Role: "PointOfContact";
   };


### PR DESCRIPTION
Here is my suggestion for issue #3. The implementation allow to write capability configuration in multiple languages directly to the main configuration. It is also possible to test that a setting is available in the configuration (ConfigHash::exists method). Plugin tests are already changed to use the implementation. 