### PR TITLE
Update regression test result after the change of coordinate order.

### DIFF
--- a/test/base/output/GetCapabilities/service-request-acceptlanguages.kvp.get
+++ b/test/base/output/GetCapabilities/service-request-acceptlanguages.kvp.get
@@ -228,10 +228,10 @@ Sovelluksissa, joissa käytetään lentosäähavaintosanomia (METAReita), tulisi
         <ows:Keyword>forecast</ows:Keyword>
         <ows:Type>string</ows:Type>
       </ows:Keywords>
-      <wcs:WGS84BoundingBox crs="http://www.opengis.net/def/crs/EPSG/0/4326" dimension="2">
-        <ows:LowerCorner>53.025 9.041</ows:LowerCorner>
-        <ows:UpperCorner>65.875 30.291</ows:UpperCorner>
-      </wcs:WGS84BoundingBox>
+      <ows:WGS84BoundingBox dimensions="2">
+        <ows:LowerCorner>9.041 53.025</ows:LowerCorner>
+        <ows:UpperCorner>30.291 65.875</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
       <wcs:CoverageId>hbm-salinity</wcs:CoverageId>
       <wcs:CoverageSubtype>RectifiedGridCoverage</wcs:CoverageSubtype>
     </wcs:CoverageSummary>
@@ -243,10 +243,10 @@ Sovelluksissa, joissa käytetään lentosäähavaintosanomia (METAReita), tulisi
         <ows:Keyword>forecast</ows:Keyword>
         <ows:Type>string</ows:Type>
       </ows:Keywords>
-      <wcs:WGS84BoundingBox crs="http://www.opengis.net/def/crs/EPSG/0/4326" dimension="2">
-        <ows:LowerCorner>53.025 9.041</ows:LowerCorner>
-        <ows:UpperCorner>65.875 30.291</ows:UpperCorner>
-      </wcs:WGS84BoundingBox>
+      <ows:WGS84BoundingBox dimensions="2">
+        <ows:LowerCorner>9.041 53.025</ows:LowerCorner>
+        <ows:UpperCorner>30.291 65.875</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
       <wcs:CoverageId>hbm-temperaturesea</wcs:CoverageId>
       <wcs:CoverageSubtype>RectifiedGridCoverage</wcs:CoverageSubtype>
     </wcs:CoverageSummary>

--- a/test/base/output/GetCapabilities/service-request-acceptversions.kvp.get
+++ b/test/base/output/GetCapabilities/service-request-acceptversions.kvp.get
@@ -229,10 +229,10 @@ Applications containing aviation weather reports (METAR) should contain the foll
         <ows:Keyword>forecast</ows:Keyword>
         <ows:Type>string</ows:Type>
       </ows:Keywords>
-      <wcs:WGS84BoundingBox crs="http://www.opengis.net/def/crs/EPSG/0/4326" dimension="2">
-        <ows:LowerCorner>53.025 9.041</ows:LowerCorner>
-        <ows:UpperCorner>65.875 30.291</ows:UpperCorner>
-      </wcs:WGS84BoundingBox>
+      <ows:WGS84BoundingBox dimensions="2">
+        <ows:LowerCorner>9.041 53.025</ows:LowerCorner>
+        <ows:UpperCorner>30.291 65.875</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
       <wcs:CoverageId>hbm-salinity</wcs:CoverageId>
       <wcs:CoverageSubtype>RectifiedGridCoverage</wcs:CoverageSubtype>
     </wcs:CoverageSummary>
@@ -244,10 +244,10 @@ Applications containing aviation weather reports (METAR) should contain the foll
         <ows:Keyword>forecast</ows:Keyword>
         <ows:Type>string</ows:Type>
       </ows:Keywords>
-      <wcs:WGS84BoundingBox crs="http://www.opengis.net/def/crs/EPSG/0/4326" dimension="2">
-        <ows:LowerCorner>53.025 9.041</ows:LowerCorner>
-        <ows:UpperCorner>65.875 30.291</ows:UpperCorner>
-      </wcs:WGS84BoundingBox>
+      <ows:WGS84BoundingBox dimensions="2">
+        <ows:LowerCorner>9.041 53.025</ows:LowerCorner>
+        <ows:UpperCorner>30.291 65.875</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
       <wcs:CoverageId>hbm-temperaturesea</wcs:CoverageId>
       <wcs:CoverageSubtype>RectifiedGridCoverage</wcs:CoverageSubtype>
     </wcs:CoverageSummary>

--- a/test/base/output/GetCapabilities/service-request-acceptversions.xml.post
+++ b/test/base/output/GetCapabilities/service-request-acceptversions.xml.post
@@ -229,10 +229,10 @@ Applications containing aviation weather reports (METAR) should contain the foll
         <ows:Keyword>forecast</ows:Keyword>
         <ows:Type>string</ows:Type>
       </ows:Keywords>
-      <wcs:WGS84BoundingBox crs="http://www.opengis.net/def/crs/EPSG/0/4326" dimension="2">
-        <ows:LowerCorner>53.025 9.041</ows:LowerCorner>
-        <ows:UpperCorner>65.875 30.291</ows:UpperCorner>
-      </wcs:WGS84BoundingBox>
+      <ows:WGS84BoundingBox dimensions="2">
+        <ows:LowerCorner>9.041 53.025</ows:LowerCorner>
+        <ows:UpperCorner>30.291 65.875</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
       <wcs:CoverageId>hbm-salinity</wcs:CoverageId>
       <wcs:CoverageSubtype>RectifiedGridCoverage</wcs:CoverageSubtype>
     </wcs:CoverageSummary>
@@ -244,10 +244,10 @@ Applications containing aviation weather reports (METAR) should contain the foll
         <ows:Keyword>forecast</ows:Keyword>
         <ows:Type>string</ows:Type>
       </ows:Keywords>
-      <wcs:WGS84BoundingBox crs="http://www.opengis.net/def/crs/EPSG/0/4326" dimension="2">
-        <ows:LowerCorner>53.025 9.041</ows:LowerCorner>
-        <ows:UpperCorner>65.875 30.291</ows:UpperCorner>
-      </wcs:WGS84BoundingBox>
+      <ows:WGS84BoundingBox dimensions="2">
+        <ows:LowerCorner>9.041 53.025</ows:LowerCorner>
+        <ows:UpperCorner>30.291 65.875</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
       <wcs:CoverageId>hbm-temperaturesea</wcs:CoverageId>
       <wcs:CoverageSubtype>RectifiedGridCoverage</wcs:CoverageSubtype>
     </wcs:CoverageSummary>

--- a/test/base/output/GetCapabilities/service-request.kvp.get
+++ b/test/base/output/GetCapabilities/service-request.kvp.get
@@ -229,10 +229,10 @@ Applications containing aviation weather reports (METAR) should contain the foll
         <ows:Keyword>forecast</ows:Keyword>
         <ows:Type>string</ows:Type>
       </ows:Keywords>
-      <wcs:WGS84BoundingBox crs="http://www.opengis.net/def/crs/EPSG/0/4326" dimension="2">
-        <ows:LowerCorner>53.025 9.041</ows:LowerCorner>
-        <ows:UpperCorner>65.875 30.291</ows:UpperCorner>
-      </wcs:WGS84BoundingBox>
+      <ows:WGS84BoundingBox dimensions="2">
+        <ows:LowerCorner>9.041 53.025</ows:LowerCorner>
+        <ows:UpperCorner>30.291 65.875</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
       <wcs:CoverageId>hbm-salinity</wcs:CoverageId>
       <wcs:CoverageSubtype>RectifiedGridCoverage</wcs:CoverageSubtype>
     </wcs:CoverageSummary>
@@ -244,10 +244,10 @@ Applications containing aviation weather reports (METAR) should contain the foll
         <ows:Keyword>forecast</ows:Keyword>
         <ows:Type>string</ows:Type>
       </ows:Keywords>
-      <wcs:WGS84BoundingBox crs="http://www.opengis.net/def/crs/EPSG/0/4326" dimension="2">
-        <ows:LowerCorner>53.025 9.041</ows:LowerCorner>
-        <ows:UpperCorner>65.875 30.291</ows:UpperCorner>
-      </wcs:WGS84BoundingBox>
+      <ows:WGS84BoundingBox dimensions="2">
+        <ows:LowerCorner>9.041 53.025</ows:LowerCorner>
+        <ows:UpperCorner>30.291 65.875</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
       <wcs:CoverageId>hbm-temperaturesea</wcs:CoverageId>
       <wcs:CoverageSubtype>RectifiedGridCoverage</wcs:CoverageSubtype>
     </wcs:CoverageSummary>

--- a/test/base/output/GetCapabilities/service-request.xml.post
+++ b/test/base/output/GetCapabilities/service-request.xml.post
@@ -229,10 +229,10 @@ Applications containing aviation weather reports (METAR) should contain the foll
         <ows:Keyword>forecast</ows:Keyword>
         <ows:Type>string</ows:Type>
       </ows:Keywords>
-      <wcs:WGS84BoundingBox crs="http://www.opengis.net/def/crs/EPSG/0/4326" dimension="2">
-        <ows:LowerCorner>53.025 9.041</ows:LowerCorner>
-        <ows:UpperCorner>65.875 30.291</ows:UpperCorner>
-      </wcs:WGS84BoundingBox>
+      <ows:WGS84BoundingBox dimensions="2">
+        <ows:LowerCorner>9.041 53.025</ows:LowerCorner>
+        <ows:UpperCorner>30.291 65.875</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
       <wcs:CoverageId>hbm-salinity</wcs:CoverageId>
       <wcs:CoverageSubtype>RectifiedGridCoverage</wcs:CoverageSubtype>
     </wcs:CoverageSummary>
@@ -244,10 +244,10 @@ Applications containing aviation weather reports (METAR) should contain the foll
         <ows:Keyword>forecast</ows:Keyword>
         <ows:Type>string</ows:Type>
       </ows:Keywords>
-      <wcs:WGS84BoundingBox crs="http://www.opengis.net/def/crs/EPSG/0/4326" dimension="2">
-        <ows:LowerCorner>53.025 9.041</ows:LowerCorner>
-        <ows:UpperCorner>65.875 30.291</ows:UpperCorner>
-      </wcs:WGS84BoundingBox>
+      <ows:WGS84BoundingBox dimensions="2">
+        <ows:LowerCorner>9.041 53.025</ows:LowerCorner>
+        <ows:UpperCorner>30.291 65.875</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
       <wcs:CoverageId>hbm-temperaturesea</wcs:CoverageId>
       <wcs:CoverageSubtype>RectifiedGridCoverage</wcs:CoverageSubtype>
     </wcs:CoverageSummary>


### PR DESCRIPTION
Regression test results weren't updated in the same branch as the change of coordinate order of WGS84BoundingBox element. So, here is the fix for that.